### PR TITLE
Fixed typos, closes https://github.com/zikula/core/issues/1525.

### DIFF
--- a/Command/GenerateDoctrineCommand.php
+++ b/Command/GenerateDoctrineCommand.php
@@ -25,7 +25,7 @@ abstract class GenerateDoctrineCommand extends GeneratorCommand
         $entity = str_replace('/', '\\', $shortcut);
 
         if (false === $pos = strpos($entity, ':')) {
-            throw new \InvalidArgumentException(sprintf('The entity name must contain a : ("%s" given, expecting something like AcmeBlogModule:Blog/Post)', $entity));
+            throw new \InvalidArgumentException(sprintf('The entity name must contain a ":" ("%s" given, expecting something like AcmeBlogModule:Post)', $entity));
         }
 
         return array(substr($entity, 0, $pos), substr($entity, $pos + 1));

--- a/Command/GenerateDoctrineEntityCommand.php
+++ b/Command/GenerateDoctrineEntityCommand.php
@@ -118,7 +118,7 @@ EOT
         $bundleNames = array_keys($this->getContainer()->get('kernel')->getBundles());
 
         while (true) {
-            $entity = $dialog->askAndValidate($output, $dialog->getQuestion('The Entity shortcut name', $input->getOption('entity')), array('zikula\Bundle\GeneratorBundle\Command\Validators', 'validateEntityName'), false, $input->getOption('entity'), $bundleNames);
+            $entity = $dialog->askAndValidate($output, $dialog->getQuestion('The Entity shortcut name', $input->getOption('entity')), array('Zikula\Bundle\GeneratorBundle\Command\Validators', 'validateEntityName'), false, $input->getOption('entity'), $bundleNames);
 
             list($bundle, $entity) = $this->parseShortcutNotation($entity);
 

--- a/Command/Validators.php
+++ b/Command/Validators.php
@@ -94,7 +94,7 @@ class Validators
     public static function validateEntityName($entity)
     {
         if (false === $pos = strpos($entity, ':')) {
-            throw new \InvalidArgumentException(sprintf('The entity name must contain a : ("%s" given, expecting something like AcmeBlogModule:Blog/Post)', $entity));
+            throw new \InvalidArgumentException(sprintf('The entity name must contain a ":" ("%s" given, expecting something like AcmeBlogModule:Post)', $entity));
         }
 
         return $entity;


### PR DESCRIPTION
I replaced `AcmeBlogModule:Blog/Post` by `AcmeBlogModule:Blog` as the `/Post` part seems confusing.
